### PR TITLE
Fix the janky local and api category sync

### DIFF
--- a/app/src/main/java/com/marinj/shoppingwarfare/feature/category/list/data/repository/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/marinj/shoppingwarfare/feature/category/list/data/repository/CategoryRepositoryImpl.kt
@@ -6,8 +6,8 @@ import com.marinj.shoppingwarfare.feature.category.list.data.model.toRemote
 import com.marinj.shoppingwarfare.feature.category.list.domain.model.Category
 import com.marinj.shoppingwarfare.feature.category.list.domain.repository.CategoryRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
 import javax.inject.Inject
 
 class CategoryRepositoryImpl @Inject constructor(
@@ -15,9 +15,12 @@ class CategoryRepositoryImpl @Inject constructor(
     private val categoryApi: CategoryApi,
 ) : CategoryRepository {
 
-    override fun observeCategories(): Flow<List<Category>> =
-        categoriesFromLocal()
-            .onStart { syncApiToLocal() }
+    override fun observeCategories(): Flow<List<Category>> = combine(
+        syncApiToLocal(),
+        categoriesFromLocal(),
+    ) { _, categoriesFromLocal ->
+        categoriesFromLocal
+    }
 
     private fun categoriesFromLocal(): Flow<List<Category>> =
         categoryDao.observeCategories().map { localCategoryList ->


### PR DESCRIPTION
There's still a hicup when you delete the item in the UI the sort for the room dao and remote aren't the same, so there's a minor blink that happens...

We'll address it at a later point