### PR TITLE
Fix waiting for API emission

### DIFF
--- a/app/src/main/java/com/marinj/shoppingwarfare/feature/cart/data/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/marinj/shoppingwarfare/feature/cart/data/repository/CartRepositoryImpl.kt
@@ -13,7 +13,8 @@ import com.marinj.shoppingwarfare.feature.cart.data.remote.CartApi
 import com.marinj.shoppingwarfare.feature.cart.domain.model.CartItem
 import com.marinj.shoppingwarfare.feature.cart.domain.repository.CartRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -22,12 +23,11 @@ class CartRepositoryImpl @Inject constructor(
     private val cartApi: CartApi,
 ) : CartRepository {
 
-    override fun observeCartItems(): Flow<List<CartItem>> = combine(
-        syncApiToLocal(),
-        cartFromLocal(),
-    ) { _, cartFromLocal ->
-        cartFromLocal
-    }
+    override fun observeCartItems(): Flow<List<CartItem>> = flowOf(Unit)
+        .flatMapLatest {
+            syncApiToLocal()
+            cartFromLocal()
+        }
 
     private fun syncApiToLocal() = cartApi.observeCartItems()
         .map { remoteCategories ->

--- a/app/src/main/java/com/marinj/shoppingwarfare/feature/category/detail/data/repository/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/marinj/shoppingwarfare/feature/category/detail/data/repository/ProductRepositoryImpl.kt
@@ -12,8 +12,10 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import javax.inject.Inject
 
 class ProductRepositoryImpl @Inject constructor(
@@ -21,12 +23,11 @@ class ProductRepositoryImpl @Inject constructor(
     private val productDao: ProductDao,
 ) : ProductRepository {
 
-    override fun observeProducts(productId: String) = combine(
-        syncApiToLocal(productId),
-        productsFromLocal(productId),
-    ) { _, productsFromLocal ->
-        productsFromLocal
-    }
+    override fun observeProducts(productId: String) = flowOf(Unit)
+        .flatMapLatest {
+            syncApiToLocal(productId).onStart { emit(emptyList()) }
+            productsFromLocal(productId)
+        }
 
     private fun productsFromLocal(
         productId: String,

--- a/app/src/main/java/com/marinj/shoppingwarfare/feature/category/detail/data/repository/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/marinj/shoppingwarfare/feature/category/detail/data/repository/ProductRepositoryImpl.kt
@@ -12,8 +12,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import javax.inject.Inject
@@ -23,11 +22,12 @@ class ProductRepositoryImpl @Inject constructor(
     private val productDao: ProductDao,
 ) : ProductRepository {
 
-    override fun observeProducts(productId: String) = flowOf(Unit)
-        .flatMapLatest {
-            syncApiToLocal(productId).onStart { emit(emptyList()) }
-            productsFromLocal(productId)
-        }
+    override fun observeProducts(productId: String) = combine(
+        syncApiToLocal(productId).onStart { emit(emptyList()) },
+        productsFromLocal(productId),
+    ) { _, fromLocal ->
+        fromLocal
+    }
 
     private fun productsFromLocal(
         productId: String,

--- a/app/src/main/java/com/marinj/shoppingwarfare/feature/category/list/data/repository/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/marinj/shoppingwarfare/feature/category/list/data/repository/CategoryRepositoryImpl.kt
@@ -7,7 +7,8 @@ import com.marinj.shoppingwarfare.feature.category.list.data.model.toRemote
 import com.marinj.shoppingwarfare.feature.category.list.domain.model.Category
 import com.marinj.shoppingwarfare.feature.category.list.domain.repository.CategoryRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -16,15 +17,11 @@ class CategoryRepositoryImpl @Inject constructor(
     private val categoryApi: CategoryApi,
 ) : CategoryRepository {
 
-    // TODO: Improve this, combine is not the operator that we want, atleast with a implementation like this,
-    // we don't want to wait for both of them to complete, what we want is to get it from the local source
-    // as fast as possible and eventually sync the remote source with the local source
-    override fun observeCategories(): Flow<List<Category>> = combine(
-        syncApiToLocal(),
-        categoriesFromLocal(),
-    ) { _, categoriesFromLocal ->
-        categoriesFromLocal
-    }
+    override fun observeCategories(): Flow<List<Category>> = flowOf(Unit)
+        .flatMapLatest {
+            syncApiToLocal()
+            categoriesFromLocal()
+        }
 
     private fun syncApiToLocal() = categoryApi.observeCategories()
         .map { remoteCategories ->


### PR DESCRIPTION
Add a inital emission in the API flow, so that combine does not wait for it's actual first emission.

With this approach we'll get the local data as fast as possible, definatly a ugly workaround